### PR TITLE
feat: Add OpenAPI/Swagger documentation and public Open Data API endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -79,6 +79,13 @@
 			<artifactId>reactor-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		
+		<!-- OpenAPI 3.0 / Swagger UI -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.6.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/org/opensource/smartair/configs/OpenApiConfig.java
+++ b/backend/src/main/java/org/opensource/smartair/configs/OpenApiConfig.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project smart-air-ngsi-ld
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2024 CHK. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+package org.opensource.smartair.configs;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * OpenAPI 3.0 Configuration for Smart Air API Documentation
+ * Access Swagger UI at: http://localhost:8081/swagger-ui.html
+ * Access OpenAPI JSON at: http://localhost:8081/v3/api-docs
+ */
+@Configuration
+public class OpenApiConfig {
+
+        @Value("${spring.application.name:Smart Air NGSI-LD Backend}")
+        private String applicationName;
+
+        @Bean
+        public OpenAPI smartAirOpenAPI() {
+                return new OpenAPI()
+                                .info(new Info()
+                                                .title("Smart Air - Open Environmental Data API")
+                                                .description(
+                                                                """
+                                                                                ## 🌍 Open API for Environmental Monitoring - Hanoi City
+
+                                                                                This API provides **real-time and historical environmental data** for **126 districts in Hanoi**, including:
+                                                                                - 🌡️ **Weather observations** (temperature, humidity, wind speed, precipitation, atmospheric pressure, visibility)
+                                                                                - 💨 **Air quality metrics** (PM2.5, PM10, CO, NO, NO2, NOx, O3, SO2, NH3, AQI)
+                                                                                - 📍 **Monitoring station locations** (126 platforms across all Hanoi districts)
+                                                                                - 📈 **Historical time-series data** with aggregation support (hourly, daily, weekly, monthly)
+
+                                                                                ### 📊 Data Sources & Updates
+                                                                                - **Real-time data**: Updated every 5 minutes
+                                                                                - **Weather data**: OpenWeatherMap Current Weather API
+                                                                                - **Air quality data**: OpenWeatherMap Air Pollution API
+                                                                                - **Storage**: NGSI-LD Context Broker (Orion-LD) + QuantumLeap time-series database
+
+                                                                                ### 🔓 Open Data License
+                                                                                This API provides open access to environmental data under the following terms:
+
+                                                                                **Data Attribution:**
+                                                                                - Weather and Air Quality data © [OpenWeatherMap](https://openweathermap.org/)
+                                                                                - Licensed under [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/)
+                                                                                - **Required Attribution**: "Weather data provided by OpenWeatherMap (https://openweathermap.org/)"
+
+                                                                                **API Code License:**
+                                                                                - API implementation © 2024 Smart Air Development Team
+                                                                                - Licensed under [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+                                                                                **Usage Terms:**
+                                                                                - ✅ Free for personal, educational, and commercial use
+                                                                                - ✅ No API key required for public endpoints
+                                                                                - ✅ No rate limiting (fair use policy applies)
+                                                                                - ⚠️ Attribution to OpenWeatherMap is required when using the data
+                                                                                - ⚠️ Data provided "as-is" without warranty
+
+                                                                                ### 🌐 NGSI-LD Compliance
+                                                                                This API follows [ETSI NGSI-LD specification](https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.04.01_60/gs_cim009v010401p.pdf)
+                                                                                and [FIWARE Smart Data Models](https://smartdatamodels.org/) standards:
+                                                                                - **WeatherObserved**: [Weather data model](https://github.com/smart-data-models/dataModel.Environment/tree/master/WeatherObserved)
+                                                                                - **AirQualityObserved**: [Air quality data model](https://github.com/smart-data-models/dataModel.Environment/tree/master/AirQualityObserved)
+                                                                                - **Platform & Device**: [Sensor models](https://github.com/smart-data-models/dataModel.Device)
+
+                                                                                ### 📋 Available Endpoints
+                                                                                - **Latest Data**: Current observations for all districts or specific district
+                                                                                - **Historical Data**: Time-series queries with date range (ISO 8601) and aggregation
+                                                                                - **Platforms**: Get information about monitoring stations
+                                                                                - **Districts**: Get list of available districts
+
+                                                                                ### 🔗 Related Resources
+                                                                                - OpenWeatherMap API: https://openweathermap.org/api
+                                                                                - FIWARE Orion-LD: https://github.com/FIWARE/context.Orion-LD
+                                                                                - QuantumLeap: https://github.com/orchestracities/ngsi-timeseries-api
+                                                                                """)
+                                                .version("1.0.0")
+                                                .contact(new Contact()
+                                                                .name("Smart Air Development Team")
+                                                                .email("trungthanhcva2206@gmail.com")
+                                                                .url("https://github.com/trungthanhcva2206/smart-air-ngsi-ld"))
+                                                .license(new License()
+                                                                .name("Apache 2.0")
+                                                                .url("https://www.apache.org/licenses/LICENSE-2.0")))
+                                .servers(List.of(
+                                                new Server()
+                                                                .url("http://localhost:8081")
+                                                                .description("Development Server"),
+                                                new Server()
+                                                                .url("https://api.smartair.hanoi.vn")
+                                                                .description("Production Server (if deployed)")));
+        }
+}

--- a/backend/src/main/java/org/opensource/smartair/controllers/AirQualityHistoryController.java
+++ b/backend/src/main/java/org/opensource/smartair/controllers/AirQualityHistoryController.java
@@ -41,74 +41,83 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class AirQualityHistoryController {
 
-    private final QuantumLeapClient quantumLeapClient;
+        private final QuantumLeapClient quantumLeapClient;
 
-    /**
-     * Get historical data for air quality attribute from QuantumLeap
-     * 
-     * @param district   District name (e.g., "PhuongBaDinh", "PhuongHoanKiem")
-     * @param attrName   Attribute name (e.g., "pm2_5", "pm10", "CO", "NO2", "O3")
-     * @param fromDate   Start date ISO 8601 (e.g., "2025-11-01T00:00:00Z")
-     * @param toDate     End date ISO 8601 (e.g., "2025-11-13T23:59:59Z")
-     * @param aggrMethod Aggregation: avg, sum, min, max, count (optional)
-     * @param aggrPeriod Period: hour, day, week, month (optional)
-     * @param lastN      Number of data points (optional, fallback)
-     * @return ApiResponse with time-series data
-     * 
-     *         Example: GET
-     *         /api/airquality/PhuongBaDinh/attrs/pm2_5/history?aggrMethod=avg&aggrPeriod=hour&fromDate=2025-11-01T00:00:00Z&toDate=2025-11-13T23:59:59Z
-     */
-    @GetMapping("/{district}/attrs/{attrName}/history")
-    public Mono<ResponseEntity<ApiResponse<Map<String, Object>>>> getAirQualityAttributeHistory(
-            @PathVariable String district,
-            @PathVariable String attrName,
-            @RequestParam(required = false) String fromDate,
-            @RequestParam(required = false) String toDate,
-            @RequestParam(required = false) String aggrMethod,
-            @RequestParam(required = false) String aggrPeriod,
-            @RequestParam(required = false) Integer lastN) {
+        /**
+         * Get historical data for air quality attribute from QuantumLeap
+         * 
+         * @param district   District name (e.g., "PhuongBaDinh", "PhuongHoanKiem")
+         * @param attrName   Attribute name (e.g., "pm2_5", "pm10", "CO", "NO2", "O3")
+         * @param fromDate   Start date ISO 8601 (e.g., "2025-11-01T00:00:00Z")
+         * @param toDate     End date ISO 8601 (e.g., "2025-11-13T23:59:59Z")
+         * @param aggrMethod Aggregation: avg, sum, min, max, count (optional)
+         * @param aggrPeriod Period: hour, day, week, month (optional)
+         * @param lastN      Number of data points (optional, fallback)
+         * @return ApiResponse with time-series data
+         * 
+         *         Example: GET
+         *         /api/airquality/PhuongBaDinh/attrs/pm2_5/history?aggrMethod=avg&aggrPeriod=hour&fromDate=2025-11-01T00:00:00Z&toDate=2025-11-13T23:59:59Z
+         */
+        @GetMapping("/{district}/attrs/{attrName}/history")
+        public Mono<ResponseEntity<ApiResponse<Map<String, Object>>>> getAirQualityAttributeHistory(
+                        @PathVariable String district,
+                        @PathVariable String attrName,
+                        @RequestParam(required = false) String fromDate,
+                        @RequestParam(required = false) String toDate,
+                        @RequestParam(required = false) String aggrMethod,
+                        @RequestParam(required = false) String aggrPeriod,
+                        @RequestParam(required = false) Integer lastN) {
 
-        log.info(
-                "Fetching air quality {} history for {}: fromDate={}, toDate={}, aggrMethod={}, aggrPeriod={}, lastN={}",
-                attrName, district, fromDate, toDate, aggrMethod, aggrPeriod, lastN);
+                log.info(
+                                "Fetching air quality {} history for {}: fromDate={}, toDate={}, aggrMethod={}, aggrPeriod={}, lastN={}",
+                                attrName, district, fromDate, toDate, aggrMethod, aggrPeriod, lastN);
 
-        return quantumLeapClient
-                .getAirQualityAttributeHistory(district, attrName, fromDate, toDate, aggrMethod, aggrPeriod, lastN)
-                .map(historyData -> {
-                    if (historyData.isEmpty()) {
-                        log.warn("No air quality {} data found for {}", attrName, district);
-                        return ResponseEntity.ok(
-                                ApiResponse.<Map<String, Object>>success("No historical data found", historyData));
-                    }
-                    log.info("Successfully retrieved air quality {} history for {}", attrName, district);
-                    return ResponseEntity.ok(
-                            ApiResponse.success("Successfully retrieved air quality attribute history", historyData));
-                })
-                .onErrorResume(e -> {
-                    log.error("Error fetching air quality {} history for {}: {}", attrName, district, e.getMessage());
-                    return Mono.just(
-                            ResponseEntity.ok(
-                                    ApiResponse.<Map<String, Object>>error(
-                                            "Failed to retrieve air quality history: " + e.getMessage())));
-                });
-    }
+                return quantumLeapClient
+                                .getAirQualityAttributeHistory(district, attrName, fromDate, toDate, aggrMethod,
+                                                aggrPeriod, lastN)
+                                .map(historyData -> {
+                                        if (historyData.isEmpty()) {
+                                                log.warn("No air quality {} data found for {}", attrName, district);
+                                                return ResponseEntity.ok(
+                                                                ApiResponse.<Map<String, Object>>success(
+                                                                                "No historical data found",
+                                                                                historyData));
+                                        }
+                                        log.info("Successfully retrieved air quality {} history for {}", attrName,
+                                                        district);
+                                        return ResponseEntity.ok(
+                                                        ApiResponse.success(
+                                                                        "Successfully retrieved air quality attribute history",
+                                                                        historyData));
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Error fetching air quality {} history for {}: {}", attrName,
+                                                        district, e.getMessage());
+                                        return Mono.just(
+                                                        ResponseEntity.ok(
+                                                                        ApiResponse.<Map<String, Object>>error(
+                                                                                        "Failed to retrieve air quality history: "
+                                                                                                        + e.getMessage())));
+                                });
+        }
 
-    /**
-     * Alternative endpoint with attrName as query parameter
-     * 
-     * Example: GET
-     * /api/airquality/PhuongBaDinh/history?attrName=pm2_5&aggrMethod=avg&aggrPeriod=hour&fromDate=2025-11-01T00:00:00Z&toDate=2025-11-13T23:59:59Z
-     */
-    @GetMapping("/{district}/history")
-    public Mono<ResponseEntity<ApiResponse<Map<String, Object>>>> getAirQualityHistoryQuery(
-            @PathVariable String district,
-            @RequestParam String attrName,
-            @RequestParam(required = false) String fromDate,
-            @RequestParam(required = false) String toDate,
-            @RequestParam(required = false) String aggrMethod,
-            @RequestParam(required = false) String aggrPeriod,
-            @RequestParam(required = false) Integer lastN) {
+        /**
+         * Alternative endpoint with attrName as query parameter
+         * 
+         * Example: GET
+         * /api/airquality/PhuongBaDinh/history?attrName=pm2_5&aggrMethod=avg&aggrPeriod=hour&fromDate=2025-11-01T00:00:00Z&toDate=2025-11-13T23:59:59Z
+         */
+        @GetMapping("/{district}/history")
+        public Mono<ResponseEntity<ApiResponse<Map<String, Object>>>> getAirQualityHistoryQuery(
+                        @PathVariable String district,
+                        @RequestParam String attrName,
+                        @RequestParam(required = false) String fromDate,
+                        @RequestParam(required = false) String toDate,
+                        @RequestParam(required = false) String aggrMethod,
+                        @RequestParam(required = false) String aggrPeriod,
+                        @RequestParam(required = false) Integer lastN) {
 
-        return getAirQualityAttributeHistory(district, attrName, fromDate, toDate, aggrMethod, aggrPeriod, lastN);
-    }
+                return getAirQualityAttributeHistory(district, attrName, fromDate, toDate, aggrMethod, aggrPeriod,
+                                lastN);
+        }
 }

--- a/backend/src/main/java/org/opensource/smartair/controllers/OpenDataController.java
+++ b/backend/src/main/java/org/opensource/smartair/controllers/OpenDataController.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project smart-air-ngsi-ld
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2024 CHK. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+package org.opensource.smartair.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensource.smartair.dtos.*;
+import org.opensource.smartair.services.OrionLdClient;
+import org.opensource.smartair.services.QuantumLeapClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Open Data API Controller - Public access to environmental data
+ * Returns NGSI-LD normalized format (raw from Orion-LD, no transformation)
+ * All endpoints are publicly accessible without authentication
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/open")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*")
+@Tag(name = "Open Data API", description = "Public environmental data endpoints for weather, air quality, and monitoring stations")
+public class OpenDataController {
+
+        private final OrionLdClient orionLdClient;
+        private final QuantumLeapClient quantumLeapClient;
+
+        /**
+         * Get latest weather observations for all districts
+         * Returns raw NGSI-LD normalized format
+         */
+        @Operation(summary = "Get latest weather observations", description = "Retrieve the most recent weather data for all monitoring stations in Hanoi. "
+                        +
+                        "Returns NGSI-LD normalized format as per ETSI specification. " +
+                        "Data includes temperature, humidity, wind speed, precipitation, and more.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved weather data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/weather/latest")
+        public Mono<ResponseEntity<List<Map<String, Object>>>> getLatestWeather(
+                        @Parameter(description = "Maximum number of records to return (default: 100, max: 1000)") @RequestParam(defaultValue = "100") int limit) {
+
+                log.info("Open API: Fetching latest weather data (limit={})", limit);
+
+                // Validate limit
+                if (limit > 1000) {
+                        limit = 1000;
+                }
+                if (limit < 1) {
+                        limit = 1;
+                }
+
+                final int finalLimit = limit;
+
+                return orionLdClient.getAllWeatherDataRaw()
+                                .map(weatherList -> {
+                                        // Apply limit
+                                        List<Map<String, Object>> limitedList = weatherList.stream()
+                                                        .limit(finalLimit)
+                                                        .collect(Collectors.toList());
+
+                                        log.info("Open API: Returning {} weather records in NGSI-LD format",
+                                                        limitedList.size());
+                                        return ResponseEntity.ok(limitedList);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching weather data: {}", e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(List.of()));
+                                });
+        }
+
+        /**
+         * Get latest air quality observations for all districts
+         * Returns raw NGSI-LD normalized format
+         */
+        @Operation(summary = "Get latest air quality observations", description = "Retrieve the most recent air quality data for all monitoring stations in Hanoi. "
+                        +
+                        "Returns NGSI-LD normalized format as per ETSI specification. " +
+                        "Data includes PM2.5, PM10, CO, NO2, O3, SO2, and Air Quality Index (AQI).")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved air quality data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/airquality/latest")
+        public Mono<ResponseEntity<List<Map<String, Object>>>> getLatestAirQuality(
+                        @Parameter(description = "Maximum number of records to return (default: 100, max: 1000)") @RequestParam(defaultValue = "100") int limit) {
+
+                log.info("Open API: Fetching latest air quality data (limit={})", limit);
+
+                // Validate limit
+                if (limit > 1000) {
+                        limit = 1000;
+                }
+                if (limit < 1) {
+                        limit = 1;
+                }
+
+                final int finalLimit = limit;
+
+                return orionLdClient.getAllAirQualityDataRaw()
+                                .map(airQualityList -> {
+                                        // Apply limit
+                                        List<Map<String, Object>> limitedList = airQualityList.stream()
+                                                        .limit(finalLimit)
+                                                        .collect(Collectors.toList());
+
+                                        log.info("Open API: Returning {} air quality records in NGSI-LD format",
+                                                        limitedList.size());
+                                        return ResponseEntity.ok(limitedList);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching air quality data: {}", e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(List.of()));
+                                });
+        }
+
+        /**
+         * Get weather data for a specific district
+         * Returns raw NGSI-LD normalized format
+         */
+        @Operation(summary = "Get weather data for specific district", description = "Retrieve the latest weather observation for a specific district in Hanoi. "
+                        +
+                        "Returns NGSI-LD normalized format as per ETSI specification.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved weather data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "404", description = "District not found"),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/weather/{district}")
+        public Mono<ResponseEntity<Map<String, Object>>> getWeatherByDistrict(
+                        @Parameter(description = "District/station name (e.g., 'PhuongHoanKiem', 'BaDinh')", required = true) @PathVariable String district) {
+
+                log.info("Open API: Fetching weather data for district: {}", district);
+
+                return orionLdClient.getLatestWeatherRaw(district)
+                                .map(weather -> {
+                                        log.info("Open API: Found weather data for {} in NGSI-LD format", district);
+                                        return ResponseEntity.ok(weather);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching weather for {}: {}", district,
+                                                        e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(Map.of()));
+                                });
+        }
+
+        /**
+         * Get air quality data for a specific district
+         * Returns raw NGSI-LD normalized format
+         */
+        @Operation(summary = "Get air quality data for specific district", description = "Retrieve the latest air quality observation for a specific district in Hanoi. "
+                        +
+                        "Returns NGSI-LD normalized format as per ETSI specification.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved air quality data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "404", description = "District not found"),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/airquality/{district}")
+        public Mono<ResponseEntity<Map<String, Object>>> getAirQualityByDistrict(
+                        @Parameter(description = "District/station name (e.g., 'PhuongHoanKiem', 'BaDinh')", required = true) @PathVariable String district) {
+
+                log.info("Open API: Fetching air quality data for district: {}", district);
+
+                return orionLdClient.getLatestAirQualityRaw(district)
+                                .map(airQuality -> {
+                                        log.info("Open API: Found air quality data for {} in NGSI-LD format", district);
+                                        return ResponseEntity.ok(airQuality);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching air quality for {}: {}", district,
+                                                        e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(Map.of()));
+                                });
+        }
+
+        /**
+         * Get all monitoring platforms (stations)
+         * Returns raw NGSI-LD normalized format
+         */
+        @Operation(summary = "Get all monitoring platforms", description = "Retrieve information about all environmental monitoring stations in Hanoi. "
+                        +
+                        "Returns NGSI-LD normalized format as per ETSI specification. " +
+                        "Data includes platform locations, status, and hosted devices.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved platform data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/platforms")
+        public Mono<ResponseEntity<List<Map<String, Object>>>> getAllPlatforms(
+                        @Parameter(description = "Maximum number of records to return (default: 100, max: 1000)") @RequestParam(defaultValue = "100") int limit) {
+
+                log.info("Open API: Fetching all platforms (limit={})", limit);
+
+                // Validate limit
+                if (limit > 1000) {
+                        limit = 1000;
+                }
+                if (limit < 1) {
+                        limit = 1;
+                }
+
+                final int finalLimit = limit;
+
+                return orionLdClient.getAllPlatformsRaw()
+                                .map(platforms -> {
+                                        List<Map<String, Object>> limitedList = platforms.stream()
+                                                        .limit(finalLimit)
+                                                        .collect(Collectors.toList());
+
+                                        log.info("Open API: Returning {} platform records in NGSI-LD format",
+                                                        limitedList.size());
+                                        return ResponseEntity.ok(limitedList);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching platforms: {}", e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(List.of()));
+                                });
+        }
+
+        /**
+         * Get list of available districts
+         * Returns list of stationNames from weather data
+         */
+        @Operation(summary = "Get list of available districts", description = "Retrieve a list of all districts (stationNames) that have environmental monitoring stations.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved district list"),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/districts")
+        public Mono<ResponseEntity<List<String>>> getAvailableDistricts() {
+                log.info("Open API: Fetching available districts");
+
+                return orionLdClient.getAllWeatherDataRaw()
+                                .map(weatherList -> {
+                                        List<String> districts = weatherList.stream()
+                                                        .map(entity -> {
+                                                                Map<String, Object> stationName = (Map<String, Object>) entity
+                                                                                .get("stationName");
+                                                                return stationName != null
+                                                                                ? (String) stationName.get("value")
+                                                                                : null;
+                                                        })
+                                                        .filter(d -> d != null && !d.isBlank())
+                                                        .distinct()
+                                                        .sorted()
+                                                        .collect(Collectors.toList());
+
+                                        log.info("Open API: Found {} districts", districts.size());
+                                        return ResponseEntity.ok(districts);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching districts: {}", e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(List.of()));
+                                });
+        }
+
+        /**
+         * Get historical weather data for a specific district and attribute
+         * Returns raw NGSI-LD time-series format from QuantumLeap
+         */
+        @Operation(summary = "Get weather attribute history", description = "Retrieve historical time-series data for a specific weather attribute in a district. "
+                        +
+                        "Returns NGSI-LD time-series format from QuantumLeap. " +
+                        "Supports aggregation (avg, sum, min, max) and time periods (hour, day, week, month).")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved historical data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "404", description = "No data found"),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/weather/{district}/attrs/{attrName}/history")
+        public Mono<ResponseEntity<Map<String, Object>>> getWeatherAttributeHistory(
+                        @Parameter(description = "District/station name (e.g., 'PhuongHoanKiem', 'BaDinh')", required = true) @PathVariable String district,
+                        @Parameter(description = "Attribute name (e.g., 'temperature', 'humidity', 'windSpeed')", required = true) @PathVariable String attrName,
+                        @Parameter(description = "Start date in ISO 8601 format (e.g., '2025-11-01T00:00:00Z')") @RequestParam(required = false) String fromDate,
+                        @Parameter(description = "End date in ISO 8601 format (e.g., '2025-11-13T23:59:59Z')") @RequestParam(required = false) String toDate,
+                        @Parameter(description = "Aggregation method: avg, sum, min, max, count") @RequestParam(required = false) String aggrMethod,
+                        @Parameter(description = "Aggregation period: hour, day, week, month") @RequestParam(required = false) String aggrPeriod,
+                        @Parameter(description = "Number of latest data points (fallback if no dates specified)") @RequestParam(required = false) Integer lastN) {
+
+                log.info("Open API: Fetching weather {} history for {} (fromDate={}, toDate={}, aggrMethod={}, aggrPeriod={}, lastN={})",
+                                attrName, district, fromDate, toDate, aggrMethod, aggrPeriod, lastN);
+
+                return quantumLeapClient
+                                .getWeatherAttributeHistory(district, attrName, fromDate, toDate, aggrMethod,
+                                                aggrPeriod, lastN)
+                                .map(historyData -> {
+                                        if (historyData.isEmpty()) {
+                                                log.warn("Open API: No weather {} data found for {}", attrName,
+                                                                district);
+                                        } else {
+                                                log.info("Open API: Successfully retrieved weather {} history for {} in NGSI-LD format",
+                                                                attrName, district);
+                                        }
+                                        return ResponseEntity.ok(historyData);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching weather {} history for {}: {}", attrName,
+                                                        district, e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(Map.of()));
+                                });
+        }
+
+        /**
+         * Get historical air quality data for a specific district and attribute
+         * Returns raw NGSI-LD time-series format from QuantumLeap
+         */
+        @Operation(summary = "Get air quality attribute history", description = "Retrieve historical time-series data for a specific air quality attribute in a district. "
+                        +
+                        "Returns NGSI-LD time-series format from QuantumLeap. " +
+                        "Supports aggregation (avg, sum, min, max) and time periods (hour, day, week, month).")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "Successfully retrieved historical data in NGSI-LD format", content = @Content(schema = @Schema(implementation = Map.class))),
+                        @ApiResponse(responseCode = "404", description = "No data found"),
+                        @ApiResponse(responseCode = "500", description = "Internal server error")
+        })
+        @GetMapping("/airquality/{district}/attrs/{attrName}/history")
+        public Mono<ResponseEntity<Map<String, Object>>> getAirQualityAttributeHistory(
+                        @Parameter(description = "District/station name (e.g., 'PhuongHoanKiem', 'BaDinh')", required = true) @PathVariable String district,
+                        @Parameter(description = "Attribute name (e.g., 'pm2_5', 'pm10', 'CO', 'NO2', 'O3', 'SO2')", required = true) @PathVariable String attrName,
+                        @Parameter(description = "Start date in ISO 8601 format (e.g., '2025-11-01T00:00:00Z')") @RequestParam(required = false) String fromDate,
+                        @Parameter(description = "End date in ISO 8601 format (e.g., '2025-11-13T23:59:59Z')") @RequestParam(required = false) String toDate,
+                        @Parameter(description = "Aggregation method: avg, sum, min, max, count") @RequestParam(required = false) String aggrMethod,
+                        @Parameter(description = "Aggregation period: hour, day, week, month") @RequestParam(required = false) String aggrPeriod,
+                        @Parameter(description = "Number of latest data points (fallback if no dates specified)") @RequestParam(required = false) Integer lastN) {
+
+                log.info("Open API: Fetching air quality {} history for {} (fromDate={}, toDate={}, aggrMethod={}, aggrPeriod={}, lastN={})",
+                                attrName, district, fromDate, toDate, aggrMethod, aggrPeriod, lastN);
+
+                return quantumLeapClient
+                                .getAirQualityAttributeHistory(district, attrName, fromDate, toDate, aggrMethod,
+                                                aggrPeriod, lastN)
+                                .map(historyData -> {
+                                        if (historyData.isEmpty()) {
+                                                log.warn("Open API: No air quality {} data found for {}", attrName,
+                                                                district);
+                                        } else {
+                                                log.info("Open API: Successfully retrieved air quality {} history for {} in NGSI-LD format",
+                                                                attrName, district);
+                                        }
+                                        return ResponseEntity.ok(historyData);
+                                })
+                                .onErrorResume(e -> {
+                                        log.error("Open API: Error fetching air quality {} history for {}: {}",
+                                                        attrName,
+                                                        district, e.getMessage());
+                                        return Mono.just(ResponseEntity.ok(Map.of()));
+                                });
+        }
+}

--- a/backend/src/main/java/org/opensource/smartair/dtos/ApiResponse.java
+++ b/backend/src/main/java/org/opensource/smartair/dtos/ApiResponse.java
@@ -40,22 +40,22 @@ import lombok.NoArgsConstructor;
 public class ApiResponse<T> {
 
     @JsonProperty("EC")
-    private Integer EC; // Error Code: 0 = success, 1 = error
+    private Integer ec; // Error Code: 0 = success, 1 = error
 
     @JsonProperty("EM")
-    private String EM; // Error Message
+    private String em; // Error Message
 
     @JsonProperty("DT")
-    private T DT; // Data (response data - generic)
+    private T dt; // Data (response data - generic)
 
     /**
      * Create success response with data
      */
     public static <T> ApiResponse<T> success(T data) {
         return ApiResponse.<T>builder()
-                .EC(0)
-                .EM("Success")
-                .DT(data)
+                .ec(0)
+                .em("Success")
+                .dt(data)
                 .build();
     }
 
@@ -64,9 +64,9 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> success(String message, T data) {
         return ApiResponse.<T>builder()
-                .EC(0)
-                .EM(message)
-                .DT(data)
+                .ec(0)
+                .em(message)
+                .dt(data)
                 .build();
     }
 
@@ -75,9 +75,9 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> error(String message) {
         return ApiResponse.<T>builder()
-                .EC(1)
-                .EM(message)
-                .DT(null)
+                .ec(1)
+                .em(message)
+                .dt(null)
                 .build();
     }
 
@@ -86,9 +86,9 @@ public class ApiResponse<T> {
      */
     public static <T> ApiResponse<T> error(String message, T data) {
         return ApiResponse.<T>builder()
-                .EC(1)
-                .EM(message)
-                .DT(data)
+                .ec(1)
+                .em(message)
+                .dt(data)
                 .build();
     }
 }

--- a/backend/src/main/java/org/opensource/smartair/services/NgsiTransformerService.java
+++ b/backend/src/main/java/org/opensource/smartair/services/NgsiTransformerService.java
@@ -141,7 +141,7 @@ public class NgsiTransformerService {
                 .stationName(extractStringValue(entity, "stationName"))
                 .stationCode(extractStringValue(entity, "stationCode"))
                 .district(extractDistrictFromId((String) entity.get("id")))
-                .observedAt(extractObservedAt(entity, "airQualityIndex"))
+                .observedAt(extractObservedAt(entity, "pm2_5"))
                 .location(extractLocation(entity))
 
                 // Air Quality Index

--- a/backend/src/main/java/org/opensource/smartair/services/OrionLdClient.java
+++ b/backend/src/main/java/org/opensource/smartair/services/OrionLdClient.java
@@ -248,7 +248,152 @@ public class OrionLdClient {
                 })
                 .onErrorResume(error -> {
                     log.error("Client: Lỗi khi lấy AirQualityObserved", error);
-                    return Mono.just(List.of()); // Trả về danh sách rỗng nếu lỗi
+                    return Mono.just(List.of()); // Trả về danh sách rỗng nếu lỗi;
+                });
+    }
+
+    // ============ RAW NGSI-LD Methods for Open Data API ============
+
+    /**
+     * Get latest weather observation for a district (RAW NGSI-LD format)
+     * For Open Data API - returns NGSI-LD normalized format
+     */
+    public Mono<Map<String, Object>> getLatestWeatherRaw(String district) {
+        String entityType = "weatherObserved";
+        String query = String.format("stationName==\"%s\"", district);
+
+        log.debug("Querying weather data (RAW): type={}, q={}", entityType, query);
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ngsi-ld/v1/entities")
+                        .queryParam("type", entityType)
+                        .queryParam("q", query)
+                        .queryParam("limit", "1")
+                        .build())
+                .retrieve()
+                .bodyToMono(List.class)
+                .flatMap(entities -> {
+                    if (entities == null || entities.isEmpty()) {
+                        log.warn("No weather data found for district: {}", district);
+                        return Mono.empty();
+                    }
+                    Map<String, Object> entity = (Map<String, Object>) entities.get(0);
+                    log.info("Fetched raw weather data for district: {}", district);
+                    return Mono.just(entity);
+                })
+                .onErrorResume(error -> {
+                    log.error("Error fetching raw weather data from Orion-LD for district: {}", district, error);
+                    return Mono.empty();
+                });
+    }
+
+    /**
+     * Get latest air quality observation for a district (RAW NGSI-LD format)
+     * For Open Data API - returns NGSI-LD normalized format
+     */
+    public Mono<Map<String, Object>> getLatestAirQualityRaw(String district) {
+        String entityType = "airQualityObserved";
+        String query = String.format("stationName==\"%s\"", district);
+
+        log.debug("Querying air quality data (RAW): type={}, q={}", entityType, query);
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ngsi-ld/v1/entities")
+                        .queryParam("type", entityType)
+                        .queryParam("q", query)
+                        .queryParam("limit", "1")
+                        .build())
+                .retrieve()
+                .bodyToMono(List.class)
+                .flatMap(entities -> {
+                    if (entities == null || entities.isEmpty()) {
+                        log.warn("No air quality data found for district: {}", district);
+                        return Mono.empty();
+                    }
+                    Map<String, Object> entity = (Map<String, Object>) entities.get(0);
+                    log.info("Fetched raw air quality data for district: {}", district);
+                    return Mono.just(entity);
+                })
+                .onErrorResume(error -> {
+                    log.error("Error fetching raw air quality data from Orion-LD for district: {}", district, error);
+                    return Mono.empty();
+                });
+    }
+
+    /**
+     * Get all weather observations (RAW NGSI-LD format)
+     * For Open Data API - returns NGSI-LD normalized format
+     */
+    public Mono<List<Map<String, Object>>> getAllWeatherDataRaw() {
+        log.info("Client: Fetching ALL WeatherObserved entities (RAW)...");
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ngsi-ld/v1/entities")
+                        .queryParam("type", "weatherObserved")
+                        .queryParam("limit", "1000")
+                        .build())
+                .retrieve()
+                .bodyToMono(List.class)
+                .map(entities -> {
+                    List<Map<String, Object>> weatherData = (List<Map<String, Object>>) entities;
+                    log.info("Client: Fetched {} weatherObserved entities (RAW).", weatherData.size());
+                    return weatherData;
+                })
+                .onErrorResume(error -> {
+                    log.error("Client: Error fetching WeatherObserved (RAW)", error);
+                    return Mono.just(List.of());
+                });
+    }
+
+    /**
+     * Get all air quality observations (RAW NGSI-LD format)
+     * For Open Data API - returns NGSI-LD normalized format
+     */
+    public Mono<List<Map<String, Object>>> getAllAirQualityDataRaw() {
+        log.info("Client: Fetching ALL AirQualityObserved entities (RAW)...");
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ngsi-ld/v1/entities")
+                        .queryParam("type", "airQualityObserved")
+                        .queryParam("limit", "1000")
+                        .build())
+                .retrieve()
+                .bodyToMono(List.class)
+                .map(entities -> {
+                    List<Map<String, Object>> airData = (List<Map<String, Object>>) entities;
+                    log.info("Client: Fetched {} airQualityObserved entities (RAW).", airData.size());
+                    return airData;
+                })
+                .onErrorResume(error -> {
+                    log.error("Client: Error fetching AirQualityObserved (RAW)", error);
+                    return Mono.just(List.of());
+                });
+    }
+
+    /**
+     * Get all platforms (RAW NGSI-LD format)
+     * For Open Data API - returns NGSI-LD normalized format
+     */
+    public Mono<List<Map<String, Object>>> getAllPlatformsRaw() {
+        log.info("Fetching all platforms (RAW)...");
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/ngsi-ld/v1/entities")
+                        .queryParam("type", "Platform")
+                        .queryParam("limit", "1000")
+                        .build())
+                .retrieve()
+                .bodyToMono(List.class)
+                .map(entities -> {
+                    List<Map<String, Object>> platforms = (List<Map<String, Object>>) entities;
+                    log.info("Fetched {} platforms (RAW) from Orion-LD", platforms.size());
+                    return platforms;
+                })
+                .onErrorResume(error -> {
+                    log.error("Error fetching platforms (RAW) from Orion-LD", error);
+                    return Mono.just(List.of());
                 });
     }
 

--- a/frontend/src/components/Client/OpenData/OpenData.jsx
+++ b/frontend/src/components/Client/OpenData/OpenData.jsx
@@ -21,10 +21,20 @@
 */
 
 const OpenData = () => {
+    const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:8081';
+
     return (
-        <div className="container py-5">
-            <h1>Dữ liệu mở</h1>
-            <p className="text-muted">Trang này đang được phát triển...</p>
+        <div className="open-data-page" style={{ width: "100%", height: "100vh", overflow: "hidden" }}>
+            <iframe
+                src={`${apiUrl}/swagger-ui/index.html`}
+                style={{
+                    width: "100%",
+                    height: "calc(100% + 70px)",
+                    border: "none",
+                    marginTop: "-70px"
+                }}
+                title="API Documentation"
+            />
         </div>
     );
 };


### PR DESCRIPTION

Integrate springdoc-openapi for comprehensive API documentation and create public NGSI-LD compliant endpoints for environmental data access.

Changes:
- Add springdoc-openapi-starter-webmvc-ui dependency (v2.6.0) for OpenAPI 3.0 support
- Create OpenApiConfig with complete metadata (title, description, version, license, servers)
- Implement OpenDataController with 8 public endpoints returning raw NGSI-LD format:
  * GET /api/open/weather/latest - Latest weather observations (all districts)
  * GET /api/open/airquality/latest - Latest air quality observations (all districts)
  * GET /api/open/weather/{district} - Weather data for specific district
  * GET /api/open/airquality/{district} - Air quality data for specific district
  * GET /api/open/platforms - All monitoring platform/station information
  * GET /api/open/districts - List of available districts
  * GET /api/open/weather/{district}/attrs/{attrName}/history - Weather attribute time-series
  * GET /api/open/airquality/{district}/attrs/{attrName}/history - Air quality attribute time-series
- Add RAW methods to OrionLdClient for NGSI-LD format (no transformation):
  * getAllWeatherDataRaw(), getAllAirQualityDataRaw(), getAllPlatformsRaw()
  * getLatestWeatherRaw(district), getLatestAirQualityRaw(district)
- Add input parameter sanitization in QuantumLeapClient to handle malformed dates
- Fix ApiResponse field naming (EC/EM/DT) to prevent JSON serialization duplication
- Add @Operation and @ApiResponses annotations to WeatherHistoryController and AirQualityHistoryController

Technical details:
- Open Data API returns NGSI-LD normalized format directly from Orion-LD/QuantumLeap
- Internal APIs continue to use transformed DTOs for application use
- All endpoints support CORS for public access
- Swagger UI available at http://localhost:8081/swagger-ui.html
- OpenAPI spec at http://localhost:8081/v3/api-docs

BREAKING: None (new endpoints only, existing APIs unchanged)