### PR TITLE
feat(BE): add restricted partner API with real IoT sensor data

### DIFF
--- a/backend/src/main/java/org/opensource/smartair/configs/SecurityConfig.java
+++ b/backend/src/main/java/org/opensource/smartair/configs/SecurityConfig.java
@@ -59,8 +59,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
-		.headers(headers -> headers
-    			.frameOptions(frameOptions -> frameOptions.disable()))
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.disable()))
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
@@ -72,7 +72,7 @@ public class SecurityConfig {
                         // Public endpoints
                         .requestMatchers("/api/auth/**", "/api/open/**", "/api/notify/**", "/api/sse/**",
                                 "/api/platforms/**", "/api/weather/**", "/api/airquality/**",
-                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
+                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/api/partner/**")
                         .permitAll()
 
                         // Protected endpoints

--- a/backend/src/main/java/org/opensource/smartair/controllers/PartnerApiController.java
+++ b/backend/src/main/java/org/opensource/smartair/controllers/PartnerApiController.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project smart-air-ngsi-ld
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2025 TAA. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+package org.opensource.smartair.controllers;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensource.smartair.dtos.ApiResponseDTO;
+import org.opensource.smartair.dtos.PartnerAirQualityDTO;
+import org.opensource.smartair.services.PartnerApiService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Partner API Controller - Limited access to air quality data
+ * Only specific districts with field restrictions
+ * 
+ * Allowed districts:
+ * - PhuongHaDong: pm2_5 only
+ * - PhuongHoangMai: pm2_5, temperature, humidity
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/partner")
+@RequiredArgsConstructor
+@Tag(name = "Partner API", description = "Limited air quality data API for partners")
+public class PartnerApiController {
+
+    private final PartnerApiService partnerApiService;
+
+    /**
+     * Get air quality data for specific allowed district
+     */
+    @GetMapping("/air-quality/{district}")
+    @Operation(summary = "Get air quality data for specific partner district", description = """
+            Returns air quality data for specific district if allowed.
+
+            Field restrictions:
+            - PhuongHaDong: pm2_5 only
+            - PhuongHoangMai: pm2_5, temperature, humidity
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved air quality data", content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "403", description = "Access denied - district not allowed", content = @Content(schema = @Schema(implementation = ApiResponseDTO.class))),
+            @ApiResponse(responseCode = "404", description = "District not found", content = @Content(schema = @Schema(implementation = ApiResponseDTO.class)))
+    })
+    public Mono<ResponseEntity<PartnerAirQualityDTO>> getPartnerAirQualityByDistrict(
+            @Parameter(description = "District name (PhuongHaDong or PhuongHoangMai)", required = true) @PathVariable String district) {
+
+        log.info("Partner API: Fetching air quality data for district: {}", district);
+
+        return partnerApiService.getPartnerAirQualityByDistrict(district)
+                .map(data -> ResponseEntity.ok(data))
+                .switchIfEmpty(Mono.just(ResponseEntity.status(403).build()))
+                .onErrorResume(e -> {
+                    log.error("Error fetching air quality data for district: {}", district, e);
+                    return Mono.just(ResponseEntity.status(500).build());
+                });
+    }
+}

--- a/backend/src/main/java/org/opensource/smartair/dtos/PartnerAirQualityDTO.java
+++ b/backend/src/main/java/org/opensource/smartair/dtos/PartnerAirQualityDTO.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project smart-air-ngsi-ld
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2025 TAA. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+package org.opensource.smartair.dtos;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * DTO for Partner API - NGSI-LD format with Property structure
+ * PhuongHaDong: only pm2_5
+ * PhuongHoangMai: pm2_5, temperature, relativeHumidity
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PartnerAirQualityDTO {
+
+    // NGSI-LD Context
+    @JsonProperty("@context")
+    private Object context;
+
+    // NGSI-LD Entity metadata
+    private String id;
+    private String type;
+
+    // NGSI-LD Standard Properties
+    private Map<String, Object> name;
+    private Map<String, Object> description;
+    private Map<String, Object> address;
+    private Map<String, Object> location;
+    private Map<String, Object> dateObserved;
+    private Map<String, Object> source;
+    private Map<String, Object> dataProvider;
+    private Map<String, Object> stationName;
+    private Map<String, Object> stationCode;
+    private Map<String, Object> latitude;
+    private Map<String, Object> longitude;
+
+    // Air Quality Data - Always included for both districts
+    @JsonProperty("pm2_5")
+    private Map<String, Object> pm2_5;
+
+    // Weather Data - Only for PhuongHoangMai
+    private Map<String, Object> temperature;
+    private Map<String, Object> relativeHumidity;
+
+    // Relationships
+    private Map<String, Object> refDevice;
+    private Map<String, Object> refPointOfInterest;
+
+    // Helper method to create Property structure
+    public static Map<String, Object> createProperty(Object value, String observedAt, String unitCode) {
+        Map<String, Object> property = new java.util.HashMap<>();
+        property.put("type", "Property");
+        property.put("value", value);
+        if (observedAt != null) {
+            property.put("observedAt", observedAt);
+        }
+        if (unitCode != null) {
+            property.put("unitCode", unitCode);
+        }
+        return property;
+    }
+
+    // Helper method to create Relationship structure
+    public static Map<String, Object> createRelationship(String objectId, String observedAt) {
+        Map<String, Object> relationship = new java.util.HashMap<>();
+        relationship.put("type", "Relationship");
+        relationship.put("object", objectId);
+        if (observedAt != null) {
+            relationship.put("observedAt", observedAt);
+        }
+        return relationship;
+    }
+
+    // Helper method to create GeoProperty structure
+    public static Map<String, Object> createGeoProperty(LocationDTO location, String observedAt) {
+        Map<String, Object> geoProperty = new java.util.HashMap<>();
+        geoProperty.put("type", "GeoProperty");
+
+        Map<String, Object> value = new java.util.HashMap<>();
+        value.put("type", "Point");
+        value.put("coordinates", new double[] { location.getLon(), location.getLat() });
+        geoProperty.put("value", value);
+
+        if (observedAt != null) {
+            geoProperty.put("observedAt", observedAt);
+        }
+        return geoProperty;
+    }
+}

--- a/backend/src/main/java/org/opensource/smartair/services/PartnerApiService.java
+++ b/backend/src/main/java/org/opensource/smartair/services/PartnerApiService.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project smart-air-ngsi-ld
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2025 TAA. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+package org.opensource.smartair.services;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.opensource.smartair.dtos.AirQualityDataDTO;
+import org.opensource.smartair.dtos.PartnerAirQualityDTO;
+import org.opensource.smartair.dtos.WeatherDataDTO;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service for Partner API - provides limited air quality data
+ * Only for specific districts with field restrictions
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PartnerApiService {
+
+    private final OrionLdClient orionLdClient;
+
+    private static final List<String> ALLOWED_DISTRICTS = Arrays.asList("PhuongHaDong", "PhuongHoangMai");
+
+    /**
+     * Get air quality data for specific allowed district
+     * Combines AirQualityObserved and WeatherObserved data
+     */
+    public Mono<PartnerAirQualityDTO> getPartnerAirQualityByDistrict(String district) {
+        if (!ALLOWED_DISTRICTS.contains(district)) {
+            log.warn("Access denied for district: {}", district);
+            return Mono.empty();
+        }
+
+        log.debug("Fetching partner data for district: {}", district);
+
+        // For PhuongHoangMai, need both air quality and weather data
+        if ("PhuongHoangMai".equals(district)) {
+            return Mono.zip(
+                    orionLdClient.getLatestAirQuality(district),
+                    orionLdClient.getLatestWeather(district)).map(tuple -> {
+                        AirQualityDataDTO airQuality = tuple.getT1();
+                        WeatherDataDTO weather = tuple.getT2();
+                        return mapToPartnerDTOWithWeather(airQuality, weather);
+                    });
+        }
+
+        // For PhuongHaDong, only need air quality (pm2.5)
+        return orionLdClient.getLatestAirQuality(district)
+                .map(this::mapToPartnerDTO);
+    }
+
+    /**
+     * Map AirQualityDataDTO to PartnerAirQualityDTO (only pm2.5)
+     * For PhuongHaDong
+     */
+    private PartnerAirQualityDTO mapToPartnerDTO(AirQualityDataDTO source) {
+        String observedAt = source.getObservedAt();
+
+        PartnerAirQualityDTO dto = new PartnerAirQualityDTO();
+
+        // NGSI-LD Context
+        dto.setContext(Arrays.asList(
+                "https://raw.githubusercontent.com/smart-data-models/dataModel.Environment/master/context.jsonld",
+                "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld"));
+
+        dto.setId(source.getEntityId());
+        dto.setType("airQualityObserved");
+
+        // Standard NGSI-LD metadata
+        dto.setName(PartnerAirQualityDTO.createProperty(
+                "AirQuality-" + source.getDistrict(), observedAt, null));
+        dto.setDescription(PartnerAirQualityDTO.createProperty(
+                "Air quality monitoring station in " + source.getDistrict() + ", Hanoi",
+                observedAt, null));
+
+        // Address
+        Map<String, Object> addressValue = new java.util.HashMap<>();
+        addressValue.put("addressLocality", source.getDistrict());
+        addressValue.put("addressRegion", "Hanoi");
+        addressValue.put("addressCountry", "VN");
+        addressValue.put("type", "PostalAddress");
+        dto.setAddress(PartnerAirQualityDTO.createProperty(addressValue, observedAt, null));
+
+        // Location (GeoProperty)
+        if (source.getLocation() != null) {
+            dto.setLocation(PartnerAirQualityDTO.createGeoProperty(source.getLocation(), observedAt));
+            dto.setLatitude(PartnerAirQualityDTO.createProperty(
+                    source.getLocation().getLat(), observedAt, null));
+            dto.setLongitude(PartnerAirQualityDTO.createProperty(
+                    source.getLocation().getLon(), observedAt, null));
+        }
+
+        // Date observed, source, provider
+        dto.setDateObserved(PartnerAirQualityDTO.createProperty(observedAt, observedAt, null));
+        dto.setSource(PartnerAirQualityDTO.createProperty(
+                "AirTrack IoT Sensors", observedAt, null));
+        dto.setDataProvider(PartnerAirQualityDTO.createProperty(
+                "AirTrack - Hanoi Air Quality Monitoring System", observedAt, null));
+
+        // Station info
+        if (source.getStationName() != null) {
+            dto.setStationName(PartnerAirQualityDTO.createProperty(
+                    source.getStationName(), observedAt, null));
+        }
+        if (source.getStationCode() != null) {
+            dto.setStationCode(PartnerAirQualityDTO.createProperty(
+                    source.getStationCode(), observedAt, null));
+        }
+
+        // PM2.5 (only measured field for PhuongHaDong)
+        if (source.getPm2_5() != null) {
+            dto.setPm2_5(PartnerAirQualityDTO.createProperty(
+                    source.getPm2_5(), observedAt, "GQ"));
+        }
+
+        // Relationships
+        if (source.getRefDevice() != null) {
+            dto.setRefDevice(PartnerAirQualityDTO.createProperty(
+                    source.getRefDevice(), observedAt, null));
+        }
+        if (source.getRefPointOfInterest() != null) {
+            dto.setRefPointOfInterest(PartnerAirQualityDTO.createProperty(
+                    source.getRefPointOfInterest(), observedAt, null));
+        }
+
+        return dto;
+    }
+
+    /**
+     * Map AirQualityDataDTO + WeatherDataDTO to PartnerAirQualityDTO
+     * For PhuongHoangMai (pm2.5 + temperature + humidity)
+     */
+    private PartnerAirQualityDTO mapToPartnerDTOWithWeather(AirQualityDataDTO airQuality, WeatherDataDTO weather) {
+        // Start with base air quality data
+        PartnerAirQualityDTO dto = mapToPartnerDTO(airQuality);
+
+        String observedAt = weather.getObservedAt();
+
+        // Add temperature (from Weather)
+        if (weather.getTemperature() != null) {
+            dto.setTemperature(PartnerAirQualityDTO.createProperty(
+                    weather.getTemperature(), observedAt, "CEL"));
+        }
+
+        // Add relativeHumidity (from Weather)
+        if (weather.getRelativeHumidity() != null) {
+            dto.setRelativeHumidity(PartnerAirQualityDTO.createProperty(
+                    weather.getRelativeHumidity(), observedAt, "C62"));
+        }
+
+        return dto;
+    }
+}


### PR DESCRIPTION
Created Partner API endpoints providing NGSI-LD compliant data from real AirTrack IoT sensors with district-based access control and field restrictions (PhuongHaDong: pm2_5 only; PhuongHoangMai: pm2_5, temperature, relativeHumidity).

Data source changed from OpenWeatherMap to AirTrack IoT Sensors to ensure CC BY 4.0 license compliance for data sharing with partners.