### PR TITLE
feat(ETL): integrate Smart Air API from TLU-SKTT1 team

### DIFF
--- a/etl/Core_ETL/etl_pipeline.py
+++ b/etl/Core_ETL/etl_pipeline.py
@@ -23,7 +23,11 @@
 """
 
 """
-ETL Pipeline for OpenWeather to Orion-LD
+ETL Pipeline for multi-source air quality data:
+1. OpenWeather API (baseline/fallback)
+2. Smart Air stations (override OpenWeather)
+3. ESP32 real sensors via MQTT/IoT Agent (final override)
+
 Dual-path architecture:
 1. Direct REST API to Orion-LD (existing path)
 2. MQTT to IoT Agent to Orion-LD (new FIWARE compliant path)
@@ -33,6 +37,7 @@ import time
 import os
 from typing import Dict
 from .openweather_client import OpenWeatherClient
+from .smart_air_client import SmartAirClient
 from .orion_client import OrionLDClient
 from .models import WeatherObservedEntity, AirQualityObservedEntity
 from .mqtt_publisher import MQTTPublisher
@@ -58,6 +63,7 @@ class ETLPipeline:
         """
         self.mode = mode or ETL_MODE
         self.weather_client = OpenWeatherClient()
+        self.smart_air_client = SmartAirClient()
         self.orion_client = OrionLDClient()
         self.request_count = 0
         self.success_count = 0
@@ -86,6 +92,101 @@ class ETLPipeline:
                 self.mqtt_enabled = False
         
         logger.info(f"ETL Pipeline initialized in '{self.mode}' mode")
+    
+    
+    def process_smart_air_override(self, district_name: str) -> bool:
+        """
+        Override AirQualityObserved entity with Smart Air data if available
+        
+        This runs AFTER OpenWeather to override pollutant values with more
+        accurate Smart Air station data when available.
+        
+        Args:
+            district_name: Name of the district (e.g., "Phuong Hoan Kiem")
+        
+        Returns:
+            True if Smart Air data was applied, False otherwise
+        """
+        # Check if this district has a Smart Air station
+        station_id = None
+        for sid, mapped_district in self.smart_air_client.STATION_MAPPING.items():
+            if mapped_district == district_name:
+                station_id = sid
+                break
+        
+        if not station_id:
+            # logger.debug(f"No Smart Air station for {district_name}, skipping override")
+            return False
+        
+        # Fetch Smart Air data
+        logger.info(f"Applying Smart Air override for {district_name} (station: {station_id})")
+        smart_air_data = self.smart_air_client.get_station_data(station_id)
+        
+        if not smart_air_data:
+            logger.warning(f"Failed to fetch Smart Air data for {station_id}")
+            return False
+        
+        # Extract pollutants from Smart Air response
+        pollutants = self.smart_air_client.extract_pollutants(smart_air_data)
+        
+        if not pollutants:
+            logger.warning(f"No pollutant data in Smart Air response for {station_id}")
+            return False
+        
+        # Build NGSI-LD PATCH payload to update only pollutant attributes
+        from .models import NGSILDEntity
+        safe_name = NGSILDEntity._slugify_ascii(district_name)
+        entity_id = f"urn:ngsi-ld:AirQualityObserved:Hanoi-{safe_name}"
+        
+        # Map Smart Air field names to NGSI-LD attribute names
+        # EXCLUDE airQualityIndex because Smart Air uses different reference scale
+        # EXCLUDE pm1 and um003 because they don't exist in standard FIWARE models
+        field_mapping = {
+            # Particulate Matter (standard fields only)
+            # 'pm1': 'pm1',  # Not in Smart Data Models - excluded
+            'pm25': 'pm2_5',
+            'pm2_5': 'pm2_5',
+            'pm10': 'pm10',
+            # Gases
+            'co': 'CO',
+            'no2': 'NO2',
+            'o3': 'O3',
+            'so2': 'SO2',
+            # Weather (override OpenWeather if available)
+            'temperature': 'temperature',
+            'relativehumidity': 'relativeHumidity',
+            'humidity': 'relativeHumidity',
+            # Ultrafine particles
+            # 'um003': 'um003',  # Not in Smart Data Models - excluded
+            # 'airqualityindex': 'airQualityIndex',  # Excluded - different scale than OpenWeather
+            # 'aqi': 'airQualityIndex'  # Excluded - different scale than OpenWeather
+        }
+        
+        update_payload = {}
+        observed_at = smart_air_data.get('dateObserved', {}).get('value')
+        
+        for smart_field, value in pollutants.items():
+            ngsi_field = field_mapping.get(smart_field)
+            if ngsi_field:
+                update_payload[ngsi_field] = NGSILDEntity.create_property(
+                    value, 
+                    observed_at=observed_at
+                )
+        
+        if not update_payload:
+            logger.warning(f"No mappable pollutants from Smart Air for {station_id}")
+            return False
+        
+        # Update entity in Orion-LD (PATCH operation)
+        success = self.orion_client.patch_entity_attributes(entity_id, update_payload)
+        
+        if success:
+            logger.info(f"Smart Air override applied: {len(update_payload)} attributes updated")
+            logger.debug(f"   Updated fields: {list(update_payload.keys())}")
+            return True
+        else:
+            logger.error(f"Failed to apply Smart Air override for {entity_id}")
+            return False
     
     
     def process_district(self, district_name: str, location: Dict) -> bool:
@@ -185,7 +286,12 @@ class ETLPipeline:
     
     
     def run_etl_cycle(self):
-        """Run one complete ETL cycle for all districts"""
+        """
+        Run one complete ETL cycle with data priority:
+        1. OpenWeather (baseline for all districts)
+        2. Smart Air (override for districts with stations)
+        3. ESP32 Sensors (final override via MQTT/IoT Agent)
+        """
         logger.info("=" * 60)
         logger.info("Starting ETL cycle for all Hanoi districts")
         logger.info(f"Mode: {self.mode.upper()}")
@@ -196,7 +302,10 @@ class ETLPipeline:
         logger.info("=" * 60)
         
         start_time = time.time()
+        smart_air_success = 0
         
+        # PHASE 1: Process all districts with OpenWeather (baseline)
+        logger.info("\nPHASE 1: OpenWeather baseline data")
         for district_name, location in HANOI_DISTRICTS.items():
             try:
                 self.process_district(district_name, location)
@@ -206,12 +315,36 @@ class ETLPipeline:
                 logger.error(f"Unexpected error processing {district_name}: {e}")
                 self.error_count += 1
         
+        # PHASE 2: Override with Smart Air data (for districts with stations)
+        logger.info("=" * 60)
+        logger.info("PHASE 2: Smart Air data override")
+        logger.info("=" * 60)
+        logger.info(f"Checking {len(self.smart_air_client.STATION_MAPPING)} Smart Air stations...")
+        for district_name in HANOI_DISTRICTS.keys():
+            try:
+                if self.process_smart_air_override(district_name):
+                    smart_air_success += 1
+                time.sleep(0.5)
+            except Exception as e:
+                logger.error(f"Smart Air override error for {district_name}: {e}")
+        
+        if smart_air_success == 0:
+            logger.info("No Smart Air overrides applied (no matching districts or data unavailable)")
+        
+        # PHASE 3: ESP32 sensors override happens automatically via MQTT/IoT Agent
+        # (no action needed here, sensors publish independently)
+        logger.info("=" * 60)
+        logger.info("PHASE 3: ESP32 real sensors (via MQTT/IoT Agent)")
+        logger.info("=" * 60)
+        logger.info("Real sensors will override automatically when they publish")
+        
         elapsed_time = time.time() - start_time
         
         logger.info("=" * 60)
         logger.info("ETL cycle completed")
         logger.info(f"Total requests: {self.request_count}")
-        logger.info(f"Successful districts: {self.success_count}")
+        logger.info(f"OpenWeather districts: {self.success_count}")
+        logger.info(f"Smart Air overrides: {smart_air_success}")
         logger.info(f"Failed districts: {self.error_count}")
         logger.info(f"Elapsed time: {elapsed_time:.2f} seconds")
         logger.info("=" * 60)

--- a/etl/Core_ETL/orion_client.py
+++ b/etl/Core_ETL/orion_client.py
@@ -135,6 +135,50 @@ class OrionLDClient:
             logger.error(f"Error updating entity {entity_id}: {e}")
             return False
     
+    def patch_entity_attributes(self, entity_id: str, attributes: Dict) -> bool:
+        """
+        Patch specific attributes of an entity in Orion-LD
+        
+        This is used to override specific pollutant values without affecting
+        other attributes (e.g., Smart Air overriding OpenWeather pollutants)
+        
+        Args:
+            entity_id: Entity ID to update
+            attributes: Dict of attributes to update (NGSI-LD Property format)
+        
+        Returns:
+            True if successful, False otherwise
+        """
+        if not attributes:
+            logger.warning(f"No attributes to patch for {entity_id}")
+            return False
+        
+        # Add @context for NGSI-LD
+        payload = {**attributes, '@context': NGSI_LD_CONTEXT}
+        
+        try:
+            url = f"{self.base_url}/ngsi-ld/v1/entities/{entity_id}/attrs"
+            response = requests.patch(
+                url,
+                json=payload,
+                headers=self.headers,
+                timeout=10
+            )
+            
+            if response.status_code == 204:
+                logger.debug(f"Successfully patched {len(attributes)} attributes in {entity_id}")
+                return True
+            else:
+                logger.error(
+                    f"Error patching entity {entity_id}: "
+                    f"{response.status_code} - {response.text}"
+                )
+                return False
+                
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error patching entity {entity_id}: {e}")
+            return False
+    
     def get_entity(self, entity_id: str) -> Optional[Dict]:
         """
         Retrieve an entity from Orion-LD

--- a/etl/Core_ETL/smart_air_client.py
+++ b/etl/Core_ETL/smart_air_client.py
@@ -1,0 +1,198 @@
+"""
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @Project Air Track NGSI-LD
+ * @Authors 
+ *    - TT (trungthanhcva2206@gmail.com)
+ *    - Tankchoi (tadzltv22082004@gmail.com)
+ *    - Panh (panh812004.apn@gmail.com)
+ * @Copyright (C) 2025 TAA. All rights reserved
+ * @GitHub https://github.com/trungthanhcva2206/smart-air-ngsi-ld
+ */
+"""
+
+"""
+Smart Air API Client for fetching real-time air quality data
+API: https://opendata.quanglv.com/api/airquality/latest
+"""
+import requests
+import logging
+from typing import Dict, Optional, List
+
+logger = logging.getLogger(__name__)
+
+
+class SmartAirClient:
+    """Client for Smart Air Quality API"""
+    
+    BASE_URL = "https://opendata.quanglv.com/api/airquality/latest"
+    REQUEST_TIMEOUT = 10  # seconds
+    
+    # Mapping: Smart Air station ID → Hanoi district name
+    STATION_MAPPING = {
+        "station-congvienhodh": "Phường Thanh Xuân",  # Công viên hồ điều hòa - Thanh Xuân
+        "station-nguyenvancu": "Phường Long Biên",   # Nguyễn Văn Cừ - Long Biên
+        "station-oceanpark": "Xã Gia Lâm",     # Ocean Park - Gia Lâm
+        # Thêm stations khác tại đây
+    }
+    
+    def __init__(self):
+        """Initialize Smart Air client"""
+        self.session = requests.Session()
+        self.session.headers.update({
+            'User-Agent': 'Smart-Air-NGSI-LD-ETL/1.0'
+        })
+    
+    def get_station_data(self, station_id: str) -> Optional[Dict]:
+        """
+        Fetch air quality data for a specific station
+        
+        Args:
+            station_id: Smart Air station ID (e.g., "station-hanoi-nguyenvancu")
+        
+        Returns:
+            Dict containing NGSI-LD formatted data or None if error
+        """
+        try:
+            params = {'stationId': station_id}
+            
+            logger.debug(f"Fetching Smart Air data for station: {station_id}")
+            response = self.session.get(
+                self.BASE_URL,
+                params=params,
+                timeout=self.REQUEST_TIMEOUT
+            )
+            response.raise_for_status()
+            
+            data = response.json()
+            
+            # Validate response structure
+            if not self._validate_response(data):
+                logger.warning(f"Invalid response structure from Smart Air for {station_id}")
+                return None
+            
+            logger.info(f"Fetched Smart Air data for {station_id}")
+            return data
+            
+        except requests.exceptions.Timeout:
+            logger.error(f"Timeout fetching Smart Air data for {station_id}")
+            return None
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Error fetching Smart Air data for {station_id}: {e}")
+            return None
+        except ValueError as e:
+            logger.error(f"Invalid JSON response from Smart Air for {station_id}: {e}")
+            return None
+    
+    def get_all_stations_data(self) -> Dict[str, Dict]:
+        """
+        Fetch data for all configured stations
+        
+        Returns:
+            Dict mapping station_id → data
+        """
+        results = {}
+        
+        for station_id in self.STATION_MAPPING.keys():
+            data = self.get_station_data(station_id)
+            if data:
+                results[station_id] = data
+        
+        logger.info(f"Fetched Smart Air data for {len(results)}/{len(self.STATION_MAPPING)} stations")
+        return results
+    
+    def get_district_name(self, station_id: str) -> Optional[str]:
+        """
+        Get Hanoi district name from Smart Air station ID
+        
+        Args:
+            station_id: Smart Air station ID
+        
+        Returns:
+            District name (e.g., "Phuong Hoan Kiem") or None
+        """
+        return self.STATION_MAPPING.get(station_id)
+    
+    def _validate_response(self, data: Dict) -> bool:
+        """
+        Validate Smart Air API response structure
+        
+        Args:
+            data: Response data from API
+        
+        Returns:
+            True if valid, False otherwise
+        """
+        required_fields = ['type', 'dateObserved', 'location']
+        
+        # Check if all required fields exist
+        if not all(field in data for field in required_fields):
+            return False
+        
+        # Check if type is AirQualityObserved
+        if data.get('type') != 'AirQualityObserved':
+            return False
+        
+        # Check if location has coordinates
+        location = data.get('location', {})
+        if location.get('type') != 'GeoProperty':
+            return False
+        
+        coordinates = location.get('value', {}).get('coordinates')
+        if not coordinates or len(coordinates) != 2:
+            return False
+        
+        return True
+    
+    def extract_pollutants(self, data: Dict) -> Dict[str, float]:
+        """
+        Extract pollutant and weather values from Smart Air response
+        
+        Args:
+            data: Smart Air NGSI-LD response
+        
+        Returns:
+            Dict mapping pollutant/weather name → value
+        """
+        pollutants = {}
+        
+        # List of fields to extract (case-insensitive)
+        pollutant_fields = [
+            'PM1', 'pm1',
+            'PM25', 'pm2_5', 'PM2.5',
+            'PM10', 'pm10',
+            'CO', 'co',
+            'NO2', 'no2',
+            'O3', 'o3',
+            'SO2', 'so2',
+            'TEMPERATURE', 'temperature',
+            'RELATIVEHUMIDITY', 'relativeHumidity', 'humidity',
+            'UM003',  # Ultrafine particles count
+            'airQualityIndex', 'AQI'
+        ]
+        
+        for field in pollutant_fields:
+            if field in data:
+                prop = data[field]
+                if isinstance(prop, dict) and 'value' in prop:
+                    # Normalize field names to lowercase with underscore
+                    normalized_name = field.lower().replace('.', '_')
+                    pollutants[normalized_name] = prop['value']
+        
+        logger.debug(f"Extracted {len(pollutants)} fields from Smart Air: {list(pollutants.keys())}")
+        return pollutants
+    
+    def close(self):
+        """Close the session"""
+        self.session.close()

--- a/etl/README.md
+++ b/etl/README.md
@@ -86,37 +86,41 @@ This ETL Pipeline is designed to meet Smart City standards with a complete FIWAR
           │ REST API                    │ MQTT Publish
           │ (NGSI-LD)                   │ (JSON)
           │                             │
-┌─────────┴─────────────────────────────┴───────┐
-│           ETL Pipeline (Python)               │
-│                                               │
-│  ┌──────────────────────────────────────┐     │
-│  │    Dual-Path Architecture            │     │
-│  │                                      │     │
-│  │  PATH 1: REST API → Orion-LD         │     │
-│  │  - Full NGSI-LD entities             │     │
-│  │  - GeoProperty (location)            │     │  
-│  │  - Relationships (refDevice)         │     │
-│  │                                      │     │
-│  │  PATH 2: MQTT → IoT Agent → Orion-LD │     │
-│  │  - Raw measurements                  │     │
-│  │  - Device provisioning               │     │
-│  │  - FIWARE compliant                  │     │
-│  └──────────────────────────────────────┘     │
-│                                               │
-│  Mode: ETL_MODE environment variable          │
-│  - 'rest': REST API only                      │
-│  - 'mqtt': MQTT → IoT Agent only              │
-│  - 'dual': Both paths (default)               │
-└───────────────┬───────────────────────────────┘
-                │
-                │ Extract (HTTP GET)
-                ▼
-       ┌────────────────────┐
-       │  OpenWeather API   │
-       │  - Weather Data    │
-       │  - Air Quality     │
-       │  - Air Track       │
-       └────────────────────┘
+┌─────────┴─────────────────────────────┴────────────────────────────┐
+│           ETL Pipeline (Python) - 3-Phase Architecture             │
+│                                                                    │
+│  ┌────────────────────────────────────────────────────────────┐    │
+│  │  PHASE 1: OpenWeather Baseline (126 districts)             │    │
+│  │  - Full NGSI-LD entities via REST API                      │    │
+│  │  - Weather + Air Quality data                              │    │
+│  │                                                            │    │
+│  │  PHASE 2: Smart Air Override (2 stations)                  │    │
+│  │  - PATCH pollutant attributes from TLU-SKTT1 sensors       │    │
+│  │  - PM2.5, PM10, CO, NO2, O3, SO2, Temp, Humidity           │    │
+│  │  - Stations: Nguyễn Văn Cừ, Ocean Park                     │    │
+│  │                                                            │    │
+│  │  PHASE 3: ESP32 Real Sensors (MQTT → IoT Agent)            │    │
+│  │  - Final override with highest priority                    │    │
+│  │  - Raw measurements via MQTT                               │    │
+│  │  - Districts: Ha Dong, Hoang Mai                           │    │
+│  └────────────────────────────────────────────────────────────┘    │
+│                                                                    │
+│  Data Priority: OpenWeather (lowest) → Smart Air → ESP32 (highest) │
+│                                                                    │
+│  Mode: ETL_MODE environment variable                               │
+│  - 'rest': REST API only                                           │
+│  - 'mqtt': MQTT → IoT Agent only                                   │
+│  - 'dual': rest + mqtt                                             │
+└───────────────┬─────────────────────┬──────────────────────────────┘
+                │                     │
+                │ Extract             │ Extract (HTTPS GET)
+                ▼                     ▼
+       ┌────────────────────┐  ┌──────────────────────────┐
+       │  OpenWeather API   │  │ Smart Air API (TLU-SKTT1)│
+       │  - Weather Data    │  │ opendata.quanglv.com     │
+       │  - Air Quality     │  │ - Real-time Sensors      │
+       └────────────────────┘  │ - NGSI-LD format         │
+                               └──────────────────────────┘
 ```
 
 ## 📊 Data Flow


### PR DESCRIPTION
- Add SmartAirClient for real sensor data from opendata.quanglv.com
- Implement 3-phase ETL: OpenWeather → Smart Air → ESP32 sensors
- Add PATCH operation for selective attribute override
- Map 3 stations (Hồ điều hòa Thanh Xuân, Nguyễn Văn Cừ, Ocean Park) to Hanoi districts
- Filter non-FIWARE attributes (pm1, um003, airQualityIndex)
- Update README with 3-source architecture diagram